### PR TITLE
Fix to build using Xcode 10.2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
 #github "LoopKit/LoopKit" == 2.2.1
-github "kdisimone/LoopKit" "anna"
+#github "kdisimone/LoopKit" "anna"
+github "LoopKit/LoopKit" == 2.2.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "kdisimone/LoopKit" "732376ef637c7bc811d3338881729f74250bd4a6"
+github "LoopKit/LoopKit" "v2.2.2"


### PR DESCRIPTION
When using Xcode 10.2 you need to use loopkit 2.2.2 to allow it to compile.