### PR TITLE
remove CompatibleLibreBluetoothDevice class (braking change)

### DIFF
--- a/Bluetooth/BluetoothSearch.swift
+++ b/Bluetooth/BluetoothSearch.swift
@@ -13,7 +13,7 @@ import os.log
 import UIKit
 
 protocol BluetoothSearchDelegate: class {
-    func didDiscoverCompatibleDevice(_ device: CompatibleLibreBluetoothDevice, allCompatibleDevices: [CompatibleLibreBluetoothDevice])
+    func didDiscoverCompatibleDevice(_ device: CBPeripheral, allCompatibleDevices: [CBPeripheral])
 }
 
 final class BluetoothSearchManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
@@ -24,9 +24,9 @@ final class BluetoothSearchManager: NSObject, CBCentralManagerDelegate, CBPeriph
     //fileprivate let deviceNames = SupportedDevices.allNames
     //fileprivate let serviceUUIDs:[CBUUID]? = [CBUUID(string: "6E400001-B5A3-F393-E0A9-E50E24DCCA9E")]
 
-    private var discoveredDevices = [CompatibleLibreBluetoothDevice]()
+    private var discoveredDevices = [CBPeripheral]()
 
-    public func addDiscoveredDevice(_ device: CompatibleLibreBluetoothDevice) {
+    public func addDiscoveredDevice(_ device: CBPeripheral) {
         discoveredDevices.append(device)
         discoveredDevices.removeDuplicates()
         discoverDelegate.didDiscoverCompatibleDevice(device, allCompatibleDevices: discoveredDevices)
@@ -83,22 +83,19 @@ final class BluetoothSearchManager: NSObject, CBCentralManagerDelegate, CBPeriph
             return
         }
 
-        // We forcefully create a compatibledevice here because we want to be able to list
-        // all devices in the gui if danger mode is on
-        let device = CompatibleLibreBluetoothDevice(identifier: peripheral.identifier.uuidString, name: name)
 
         if SupportedDevices.isSupported(peripheral) { //deviceNames.contains(name) {
 
-            print("dabear:: did recognize device: \(name): \(device.identifier)")
-            self.addDiscoveredDevice(device)
+            print("dabear:: did recognize device: \(name): \(peripheral.identifier)")
+            self.addDiscoveredDevice(peripheral)
         } else {
             if UserDefaults.standard.dangerModeActivated {
                 //allow listing any device when danger mode is active
 
-                print("dabear:: did add unknown device due to dangermode being active \(device.name): \(device.identifier)")
-                self.addDiscoveredDevice(device)
+                print("dabear:: did add unknown device due to dangermode being active \(peripheral.name): \(peripheral.identifier)")
+                self.addDiscoveredDevice(peripheral)
             } else {
-                print("dabear:: did not add unknown device: \(device.name): \(device.identifier)")
+                print("dabear:: did not add unknown device: \(peripheral.name): \(peripheral.identifier)")
             }
         }
     }

--- a/Bluetooth/BluetoothSearch.swift
+++ b/Bluetooth/BluetoothSearch.swift
@@ -74,6 +74,8 @@ final class BluetoothSearchManager: NSObject, CBCentralManagerDelegate, CBPeriph
                 //os_log("Central Manager was powered on, scanningformiaomiao: state: %{public}@", log: MiaoMiaoBluetoothManager.bt_log, type: .default, String(describing: state))
 
                 scanForCompatibleDevices() // power was switched on, while app is running -> reconnect.
+        @unknown default:
+            fatalError("libre bluetooth state unhandled")
         }
     }
 

--- a/Bluetooth/CBPeripheral+SupportedDevices.swift
+++ b/Bluetooth/CBPeripheral+SupportedDevices.swift
@@ -1,0 +1,76 @@
+//
+//  CBPeripheral+CompatibleDevice.swift
+//  MiaomiaoClient
+//
+//  Created by Bjørn Inge Berg on 30/12/2019.
+//  Copyright © 2019 Mark Wilson. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import CoreBluetooth
+
+
+
+public enum SupportedDevices: Int, CaseIterable {
+    case MiaoMiao = 0
+    case Bubble = 1
+
+    public var name: String {
+        switch self {
+        case .Bubble:
+            return "bubble"
+        case .MiaoMiao:
+            return "miaomiao"
+        }
+    }
+
+    public static func isSupported(_ peripheral: CBPeripheral ) -> Bool {
+        if let name = peripheral.name?.lowercased() {
+            return allNames.contains {
+                //$0.starts(with: name) // miaomiao.startswith("miaomiao2_xxx")
+                name.starts(with: $0) // miaomiao2_xxx.startswith("miaomia")
+            }
+        }
+        return false
+    }
+
+    public static var allNames: [String] {
+            SupportedDevices.allCases.map { $0.name }
+    }
+}
+
+
+
+extension CBPeripheral{
+
+
+    public var bridgeType: SupportedDevices? {
+        guard let name = self.name?.lowercased() else {
+            return nil
+        }
+        switch name {
+        case let x where x.starts(with: "miaomiao"):
+            return SupportedDevices.MiaoMiao
+        case let x where x.starts(with: "bubble"):
+            return SupportedDevices.Bubble
+        default:
+            return nil
+        }
+    }
+
+    public var smallImage: UIImage? {
+           let bundle = Bundle.current
+           print("dabear:: bridgetype is \(bridgeType)")
+
+           guard let bridgeType = bridgeType else {
+               return nil
+           }
+           switch bridgeType {
+           case .Bubble:
+               return UIImage(named: "bubble", in: bundle, compatibleWith: nil)
+           case .MiaoMiao:
+               return UIImage(named: "miaomiao-small", in: bundle, compatibleWith: nil)
+           }
+       }
+}

--- a/Bluetooth/CBPeripheral+SupportedDevices.swift
+++ b/Bluetooth/CBPeripheral+SupportedDevices.swift
@@ -36,41 +36,10 @@ public enum SupportedDevices: Int, CaseIterable {
     }
 
     public static var allNames: [String] {
-            SupportedDevices.allCases.map { $0.name }
+        SupportedDevices.allCases.map { $0.name }
     }
 }
 
 
 
-extension CBPeripheral{
 
-
-    public var bridgeType: SupportedDevices? {
-        guard let name = self.name?.lowercased() else {
-            return nil
-        }
-        switch name {
-        case let x where x.starts(with: "miaomiao"):
-            return SupportedDevices.MiaoMiao
-        case let x where x.starts(with: "bubble"):
-            return SupportedDevices.Bubble
-        default:
-            return nil
-        }
-    }
-
-    public var smallImage: UIImage? {
-           let bundle = Bundle.current
-           print("dabear:: bridgetype is \(bridgeType)")
-
-           guard let bridgeType = bridgeType else {
-               return nil
-           }
-           switch bridgeType {
-           case .Bubble:
-               return UIImage(named: "bubble", in: bundle, compatibleWith: nil)
-           case .MiaoMiao:
-               return UIImage(named: "miaomiao-small", in: bundle, compatibleWith: nil)
-           }
-       }
-}

--- a/Bluetooth/LibreBluetoothManager+Miaomiao.swift
+++ b/Bluetooth/LibreBluetoothManager+Miaomiao.swift
@@ -211,7 +211,7 @@ extension LibreBluetoothManager {
 
         print("dabear: miaomiaoRequestData")
 
-        peripheral.writeValue(Data(bytes: [0xF0]), for: writeCharacteristics, type: .withResponse)
+        peripheral.writeValue(Data([0xF0]), for: writeCharacteristics, type: .withResponse)
     }
 
     func miaomiaoDidUpdateValueForNotifyCharacteristics(_ value: Data, peripheral: CBPeripheral) {
@@ -278,7 +278,7 @@ extension LibreBluetoothManager {
         print("confirming new sensor")
         if let writeCharacteristic = writeCharacteristic {
             print("confirmed new sensor")
-            peripheral.writeValue(Data(bytes: [0xD3, 0x01]), for: writeCharacteristic, type: .withResponse)
+            peripheral.writeValue(Data([0xD3, 0x01]), for: writeCharacteristic, type: .withResponse)
         } else {
             print("could not confirm new sensor")
         }

--- a/Bluetooth/LibreBluetoothManager.swift
+++ b/Bluetooth/LibreBluetoothManager.swift
@@ -215,6 +215,8 @@ final class LibreBluetoothManager: NSObject, CBCentralManagerDelegate, CBPeriphe
                 os_log("Central Manager was powered on, scanningformiaomiao: state: %{public}@", log: LibreBluetoothManager.bt_log, type: .default, String(describing: state))
                 scanForDevices() // power was switched on, while app is running -> reconnect.
             }
+        @unknown default:
+            fatalError("libre bluetooth state unhandled")
         }
     }
 

--- a/Bluetooth/LibreBluetoothManager.swift
+++ b/Bluetooth/LibreBluetoothManager.swift
@@ -24,83 +24,8 @@ public enum BluetoothmanagerState: String {
     case powerOff = "powerOff"
 }
 
-public enum SupportedDevices: Int, CaseIterable {
-    case MiaoMiao = 0
-    case Bubble = 1
-
-    public var name: String {
-        switch self {
-        case .Bubble:
-            return "bubble"
-        case .MiaoMiao:
-            return "miaomiao"
-        }
-    }
-
-    public static func isSupported(_ peripheral: CBPeripheral ) -> Bool {
-        if let name = peripheral.name?.lowercased() {
-            return allNames.contains {
-                //$0.starts(with: name) // miaomiao.startswith("miaomiao2_xxx")
-                name.starts(with: $0) // miaomiao2_xxx.startswith("miaomia")
-            }
-        }
-        return false
-    }
-
-    public static var allNames: [String] {
-            SupportedDevices.allCases.map { $0.name }
-    }
-}
 
 
-public struct CompatibleLibreBluetoothDevice: Hashable, Codable {
-    public var identifier: String
-    public var name: String
-
-    public var bridgeType: SupportedDevices? {
-        switch self.name.lowercased() {
-        case let x where x.starts(with: "miaomiao"):
-            return SupportedDevices.MiaoMiao
-        case let x where x.starts(with: "bubble"):
-            return SupportedDevices.Bubble
-        default:
-            return nil
-        }
-    }
-
-    public init(identifier: String, from type: SupportedDevices) {
-        self.init(identifier: identifier, name: type.name)
-    }
-
-    public init(identifier: String, name: String) {
-        self.identifier = identifier
-        self.name = name
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(identifier.hashValue)
-        hasher.combine(name.hashValue)
-    }
-
-    public static func == (lhs: CompatibleLibreBluetoothDevice, rhs: CompatibleLibreBluetoothDevice) -> Bool {
-        lhs.identifier == rhs.identifier && lhs.name == rhs.name
-    }
-
-    public var smallImage: UIImage? {
-        let bundle = Bundle.current
-        print("dabear:: bridgetype is \(bridgeType)")
-
-        guard let bridgeType = bridgeType else {
-            return nil
-        }
-        switch bridgeType {
-        case .Bubble:
-            return UIImage(named: "bubble", in: bundle, compatibleWith: nil)
-        case .MiaoMiao:
-            return UIImage(named: "miaomiao-small", in: bundle, compatibleWith: nil)
-        }
-    }
-}
 
 protocol LibreBluetoothManagerDelegate: class {
     // Can happen on any queue
@@ -110,15 +35,6 @@ protocol LibreBluetoothManagerDelegate: class {
     func libreBluetoothManagerDidUpdate(sensorData: SensorData, and Device: BluetoothBridgeMetaData)
 }
 
-public extension CBPeripheral {
-    func asCompatibleBluetoothDevice() -> CompatibleLibreBluetoothDevice? {
-        if SupportedDevices.isSupported(self), let name = self.name {
-            return CompatibleLibreBluetoothDevice(identifier: self.identifier.uuidString, name: name)
-        }
-
-        return nil
-    }
-}
 
 final class LibreBluetoothManager: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     // MARK: - Properties
@@ -140,9 +56,7 @@ final class LibreBluetoothManager: NSObject, CBCentralManagerDelegate, CBPeriphe
         return peripheral?.identifier
     }
 
-    public func peripheralAsCompatibleDevice() -> CompatibleLibreBluetoothDevice? {
-        return peripheral?.asCompatibleBluetoothDevice()
-    }
+
 
     private let managerQueue = DispatchQueue(label: "no.bjorninge.bluetoothManagerQueue", qos: .utility)
     private let delegateQueue = DispatchQueue(label: "no.bjorninge.delegateQueue", qos: .utility)
@@ -322,13 +236,13 @@ final class LibreBluetoothManager: NSObject, CBCentralManagerDelegate, CBPeriphe
         }
 
         if let preselected = UserDefaults.standard.preSelectedDevice {
-            if peripheral.identifier.uuidString == preselected.identifier {
+            if peripheral.identifier.uuidString == preselected {
                 os_log("Did connect to preselected %{public}@ with identifier %{public}@,", log: LibreBluetoothManager.bt_log, type: .default, String(describing: peripheral.name), String(describing: peripheral.identifier.uuidString))
                 self.peripheral = peripheral
 
                 self.connect(force: true)
             } else {
-                os_log("Did not connect to %{public}@ with identifier %{public}@, because another device with identifier %{public}@ was selected", log: LibreBluetoothManager.bt_log, type: .default, String(describing: peripheral.name), String(describing: peripheral.identifier.uuidString), preselected.identifier)
+                os_log("Did not connect to %{public}@ with identifier %{public}@, because another device with identifier %{public}@ was selected", log: LibreBluetoothManager.bt_log, type: .default, String(describing: peripheral.name), String(describing: peripheral.identifier.uuidString), preselected)
             }
 
             return
@@ -481,7 +395,7 @@ final class LibreBluetoothManager: NSObject, CBCentralManagerDelegate, CBPeriphe
             os_log("Characteristic update error: %{public}@", log: LibreBluetoothManager.bt_log, type: .error, "\(error.localizedDescription)")
         } else {
             if characteristic.uuid == notifyCharacteristicUUID, let value = characteristic.value {
-                guard let bridge = peripheral.asCompatibleBluetoothDevice()?.bridgeType else {
+                guard let bridge = peripheral.bridgeType else {
                     return
                 }
 
@@ -503,7 +417,7 @@ final class LibreBluetoothManager: NSObject, CBCentralManagerDelegate, CBPeriphe
     // Miaomiao specific commands
 
     func requestData() {
-        guard let peripheral = peripheral, let bridge = peripheral.asCompatibleBluetoothDevice()?.bridgeType else {
+        guard let peripheral = peripheral, let bridge = peripheral.bridgeType else {
             return
         }
 
@@ -518,7 +432,7 @@ final class LibreBluetoothManager: NSObject, CBCentralManagerDelegate, CBPeriphe
     }
 
     func handleCompleteMessage() {
-        guard let bridge = peripheral?.asCompatibleBluetoothDevice()?.bridgeType else {
+        guard let bridge = peripheral?.bridgeType else {
             return
         }
 
@@ -538,7 +452,7 @@ final class LibreBluetoothManager: NSObject, CBCentralManagerDelegate, CBPeriphe
 
 extension LibreBluetoothManager {
     public var manufacturer: String {
-        guard let bridgeType = self.peripheralAsCompatibleDevice()?.bridgeType else {
+        guard let bridgeType = self.peripheral?.bridgeType else {
             return "n/a"
         }
         switch bridgeType {
@@ -565,8 +479,19 @@ extension LibreBluetoothManager {
     }
 }
 
+
+
+
+
 //these are extensions to return properties (for inspection on the main ui) that exist on the queue only
 extension LibreBluetoothManager {
+    var OnQueue_peripheral: CBPeripheral? {
+        syncOnManagerQueue { manager  in
+            manager?.peripheral
+
+        }
+
+    }
     var OnQueue_metadata: BluetoothBridgeMetaData? {
         syncOnManagerQueue { manager  in
             manager?.metadata

--- a/Common/CBPeripheral.swift
+++ b/Common/CBPeripheral.swift
@@ -1,0 +1,9 @@
+//
+//  CBPeripheral.swift
+//  MiaomiaoClient
+//
+//  Created by Bjørn Inge Berg on 31/12/2019.
+//  Copyright © 2019 Mark Wilson. All rights reserved.
+//
+
+import Foundation

--- a/Common/CBPeripheral.swift
+++ b/Common/CBPeripheral.swift
@@ -7,3 +7,38 @@
 //
 
 import Foundation
+import CoreBluetooth
+import UIKit
+import MiaomiaoClient
+extension CBPeripheral{
+
+
+    public var bridgeType: SupportedDevices? {
+        guard let name = self.name?.lowercased() else {
+            return nil
+        }
+        switch name {
+        case let x where x.starts(with: "miaomiao"):
+            return SupportedDevices.MiaoMiao
+        case let x where x.starts(with: "bubble"):
+            return SupportedDevices.Bubble
+        default:
+            return nil
+        }
+    }
+
+    public var smallImage: UIImage? {
+       let bundle = Bundle.current
+       print("dabear:: bridgetype is \(bridgeType)")
+
+       guard let bridgeType = bridgeType else {
+           return nil
+       }
+       switch bridgeType {
+       case .Bubble:
+           return UIImage(named: "bubble", in: bundle, compatibleWith: nil)
+       case .MiaoMiao:
+           return UIImage(named: "miaomiao-small", in: bundle, compatibleWith: nil)
+       }
+   }
+}

--- a/Common/DateExtensions.swift
+++ b/Common/DateExtensions.swift
@@ -43,7 +43,7 @@ public extension Date {
         return date
     }
 
-    public static var LocaleWantsAMPM: Bool {
+    static var LocaleWantsAMPM: Bool {
         DateFormatter.dateFormat(fromTemplate: "j", options: 0, locale: NSLocale.current)!.contains("a")
     }
 }

--- a/Common/GlucoseSchedules.swift
+++ b/Common/GlucoseSchedules.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import HealthKit
-import MiaomiaoClient
+//import MiaomiaoClient
 public enum GlucoseScheduleAlarmResult: Int, CaseIterable {
     case none = 0
     case low

--- a/Common/UserDefaults+Bluetooth.swift
+++ b/Common/UserDefaults+Bluetooth.swift
@@ -17,7 +17,7 @@ extension UserDefaults {
 
     public var preSelectedDevice: String? {
         get {
-            print("getting Key.bluetoothDeviceUUIDString.rawValue: \(Key.bluetoothDeviceUUIDString.rawValue) ")
+            
             if let astr = string(forKey: Key.bluetoothDeviceUUIDString.rawValue) {
                 return astr.count > 0 ? astr : nil
             }

--- a/Common/UserDefaults+Bluetooth.swift
+++ b/Common/UserDefaults+Bluetooth.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import MiaomiaoClient
+//import MiaomiaoClient
 
 extension UserDefaults {
     private enum Key: String {

--- a/Common/UserDefaults+Bluetooth.swift
+++ b/Common/UserDefaults+Bluetooth.swift
@@ -11,30 +11,26 @@ import MiaomiaoClient
 
 extension UserDefaults {
     private enum Key: String {
-        case bluetoothDeviceUUID = "no.bjorninge.bluetoothDeviceUUID"
-        case bluetoothDevice = "no.bjorninge.bluetoothDevice"
+        case bluetoothDeviceUUIDString = "no.bjorninge.bluetoothDeviceUUIDString"
+
     }
 
-    public var preSelectedDevice: CompatibleLibreBluetoothDevice? {
+    public var preSelectedDevice: String? {
         get {
-            if let savedPreSelectedDevice = object(forKey: Key.bluetoothDevice.rawValue) as? Data {
-                let decoder = JSONDecoder()
-                if let loadedPreselectedDevice = try? decoder.decode(CompatibleLibreBluetoothDevice.self, from: savedPreSelectedDevice) {
-                    return loadedPreselectedDevice
-                }
+            print("getting Key.bluetoothDeviceUUIDString.rawValue: \(Key.bluetoothDeviceUUIDString.rawValue) ")
+            if let astr = string(forKey: Key.bluetoothDeviceUUIDString.rawValue) {
+                return astr.count > 0 ? astr : nil
             }
-
             return nil
         }
         set {
-            let encoder = JSONEncoder()
-            if let val = newValue {
-                if let encoded = try? encoder.encode(val) {
-                    set(encoded, forKey: Key.bluetoothDevice.rawValue)
-                }
+            if let newValue = newValue {
+                set(newValue, forKey: Key.bluetoothDeviceUUIDString.rawValue)
             } else {
-                set("", forKey: Key.bluetoothDevice.rawValue)
+                removeObject(forKey: Key.bluetoothDeviceUUIDString.rawValue)
             }
+
         }
+
     }
 }

--- a/MiaomiaoClient.xcodeproj/project.pbxproj
+++ b/MiaomiaoClient.xcodeproj/project.pbxproj
@@ -81,6 +81,9 @@
 		2791064623B96B07004B362F /* UIApplication+metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2791064523B96B07004B362F /* UIApplication+metadata.swift */; };
 		2791064723B96B07004B362F /* UIApplication+metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2791064523B96B07004B362F /* UIApplication+metadata.swift */; };
 		2795404F2165502600D657E5 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2795404E2165502600D657E5 /* main.swift */; };
+		27C175E223BAA99100414F28 /* CBPeripheral+SupportedDevices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C175E123BAA99100414F28 /* CBPeripheral+SupportedDevices.swift */; };
+		27C175E423BAC33F00414F28 /* CBPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C175E323BAC33F00414F28 /* CBPeripheral.swift */; };
+		27C175E523BAC37100414F28 /* CBPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C175E323BAC33F00414F28 /* CBPeripheral.swift */; };
 		27C335B82165667300CF0868 /* LibreGlucose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C418AE1CE0488900405B6A /* LibreGlucose.swift */; };
 		27C335B9216566C500CF0868 /* MiaomiaoClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 432B0E881CDFC3C50045347B /* MiaomiaoClient.framework */; };
 		27CBEB3C225FB3A7004F7BF5 /* NibLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CBEB3B225FB3A7004F7BF5 /* NibLoadable.swift */; };
@@ -228,6 +231,8 @@
 		2791064523B96B07004B362F /* UIApplication+metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+metadata.swift"; sourceTree = "<group>"; };
 		2795404C2165502600D657E5 /* clitester */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = clitester; sourceTree = BUILT_PRODUCTS_DIR; };
 		2795404E2165502600D657E5 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		27C175E123BAA99100414F28 /* CBPeripheral+SupportedDevices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CBPeripheral+SupportedDevices.swift"; sourceTree = "<group>"; };
+		27C175E323BAC33F00414F28 /* CBPeripheral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBPeripheral.swift; sourceTree = "<group>"; };
 		27C335E021667C7A00CF0868 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		27C335E221667C7B00CF0868 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		27C335E521667C7B00CF0868 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -408,6 +413,7 @@
 				271EDF3C22F3658D00E1C8B3 /* LibreBluetoothManager+Miaomiao.swift */,
 				2729D676221F421C0030E1B8 /* BluetoothBridgeMetaData.swift */,
 				272BF9C8233D3F5A00AD38AA /* MiaomiaoTestMessage.swift */,
+				27C175E123BAA99100414F28 /* CBPeripheral+SupportedDevices.swift */,
 			);
 			path = Bluetooth;
 			sourceTree = "<group>";
@@ -664,6 +670,7 @@
 				271EDF2422EC739F00E1C8B3 /* UserDefaults+Bluetooth.swift */,
 				272BF9C22338044600AD38AA /* DataExtensions.swift */,
 				2791064523B96B07004B362F /* UIApplication+metadata.swift */,
+				27C175E323BAC33F00414F28 /* CBPeripheral.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1008,6 +1015,7 @@
 			files = (
 				27E3C39F222EE9A80036AAC7 /* LibreOOPWebExtensions.swift in Sources */,
 				27CFAB5F224AB27B006DEFE3 /* CollectionExtensions.swift in Sources */,
+				27C175E423BAC33F00414F28 /* CBPeripheral.swift in Sources */,
 				27E3C390222EDF560036AAC7 /* LibreError.swift in Sources */,
 				4325E9CF210E6A0A00969CE5 /* HKUnit.swift in Sources */,
 				27CFAB59224977B9006DEFE3 /* GlucoseSmoothing.swift in Sources */,
@@ -1016,6 +1024,7 @@
 				272BF9C9233D3F5A00AD38AA /* MiaomiaoTestMessage.swift in Sources */,
 				2729D69F221F44670030E1B8 /* SensorState.swift in Sources */,
 				27408E582370D3C3002C71C8 /* ConcreteSensorDisplayable.swift in Sources */,
+				27C175E223BAA99100414F28 /* CBPeripheral+SupportedDevices.swift in Sources */,
 				27D0DA6B2231CBB7007BBB2C /* DateExtensions.swift in Sources */,
 				271EDF2622EC755D00E1C8B3 /* UserDefaults+Bluetooth.swift in Sources */,
 				27E3C398222EE9450036AAC7 /* LibreOOPDefaults.swift in Sources */,
@@ -1066,6 +1075,7 @@
 				27E0968622A6F64800B3164D /* SnoozeViewController.swift in Sources */,
 				271EDF3322F0946400E1C8B3 /* BluetoothSearch.swift in Sources */,
 				27E0969B22B94D4400B3164D /* CustomDatePickerViewController.swift in Sources */,
+				27C175E523BAC37100414F28 /* CBPeripheral.swift in Sources */,
 				27E0968422A6EFCD00B3164D /* SnoozeView.swift in Sources */,
 				43A8EC97210E680100A81379 /* ShareService+UI.swift in Sources */,
 				275C3D99229AA88200E27439 /* MMSwitchTableViewCell.swift in Sources */,

--- a/MiaomiaoClient.xcodeproj/project.pbxproj
+++ b/MiaomiaoClient.xcodeproj/project.pbxproj
@@ -805,7 +805,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0940;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "Mark Wilson";
 				TargetAttributes = {
 					27249309232F03E400AFE86A = {
@@ -841,10 +841,9 @@
 			};
 			buildConfigurationList = 432B0E821CDFC3C50045347B /* Build configuration list for PBXProject "MiaomiaoClient" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 				fr,
@@ -1198,7 +1197,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1230,7 +1229,7 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1263,6 +1262,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = L28K36YETG;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1283,6 +1283,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = L28K36YETG;
+				ENABLE_HARDENED_RUNTIME = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1430,7 +1431,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = L28K36YETG;
@@ -1460,7 +1461,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = L28K36YETG;

--- a/MiaomiaoClient.xcodeproj/xcshareddata/xcschemes/Cartfile.xcscheme
+++ b/MiaomiaoClient.xcodeproj/xcshareddata/xcschemes/Cartfile.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:MiaomiaoClient.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MiaomiaoClient.xcodeproj/xcshareddata/xcschemes/MiaomiaoClient.xcscheme
+++ b/MiaomiaoClient.xcodeproj/xcshareddata/xcschemes/MiaomiaoClient.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "432B0E871CDFC3C50045347B"
+            BuildableName = "MiaomiaoClient.framework"
+            BlueprintName = "MiaomiaoClient"
+            ReferencedContainer = "container:MiaomiaoClient.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "432B0E871CDFC3C50045347B"
-            BuildableName = "MiaomiaoClient.framework"
-            BlueprintName = "MiaomiaoClient"
-            ReferencedContainer = "container:MiaomiaoClient.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/MiaomiaoClient.xcodeproj/xcshareddata/xcschemes/MiaomiaoClientUI.xcscheme
+++ b/MiaomiaoClient.xcodeproj/xcshareddata/xcschemes/MiaomiaoClientUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/MiaomiaoClient.xcodeproj/xcshareddata/xcschemes/singleviewtesterapp2.xcscheme
+++ b/MiaomiaoClient.xcodeproj/xcshareddata/xcschemes/singleviewtesterapp2.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:MiaomiaoClient.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:MiaomiaoClient.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/MiaomiaoClient/MiaoMiaoClientManager.swift
+++ b/MiaomiaoClient/MiaoMiaoClientManager.swift
@@ -403,8 +403,8 @@ extension MiaoMiaoClientManager {
         return "n/a"
     }
 
-    public func getDeviceType() -> String? {
-        proxy?.OnQueue_peripheral?.bridgeType?.name
+    public func getDeviceType() -> String {
+        proxy?.OnQueue_peripheral?.bridgeType?.name ?? "Unknown"
     }
     public func getSmallImage() -> UIImage? {
         proxy?.OnQueue_peripheral?.smallImage ??

--- a/MiaomiaoClient/MiaoMiaoClientManager.swift
+++ b/MiaomiaoClient/MiaoMiaoClientManager.swift
@@ -43,10 +43,9 @@ public final class MiaoMiaoClientManager: CGMManager, LibreBluetoothManagerDeleg
 
     public var managedDataInterval: TimeInterval?
 
-    public func getSmallImage() -> UIImage? {
-        UserDefaults.standard.preSelectedDevice?.smallImage ??
-            UIImage(named: "libresensor", in:  Bundle.current, compatibleWith: nil)
-    }
+   
+
+
 
     public var device: HKDevice? {
          proxy?.OnQueue_device
@@ -402,5 +401,13 @@ extension MiaoMiaoClientManager {
             return "\(bat)%"
         }
         return "n/a"
+    }
+
+    public func getDeviceType() -> String? {
+        proxy?.OnQueue_peripheral?.bridgeType?.name
+    }
+    public func getSmallImage() -> UIImage? {
+        proxy?.OnQueue_peripheral?.smallImage ??
+        UIImage(named: "libresensor", in:  Bundle.current, compatibleWith: nil)
     }
 }

--- a/MiaomiaoClientUI/Cells/AlarmTimeInputRangeCell/AlarmTimeInputRangeCell.swift
+++ b/MiaomiaoClientUI/Cells/AlarmTimeInputRangeCell/AlarmTimeInputRangeCell.swift
@@ -104,7 +104,7 @@ class AlarmTimeInputRangeCell: UITableViewCell, UITextFieldDelegate {
     }
 
     func textFieldDidEndEditing(_ textField: UITextField) {
-        let value = valueNumberFormatter.number(from: textField.text ?? "")?.doubleValue ?? 0
+        
 
         switch textField {
         case minValueTextField:

--- a/MiaomiaoClientUI/Cells/LFTimePickerController/CustomDatePickerViewController.swift
+++ b/MiaomiaoClientUI/Cells/LFTimePickerController/CustomDatePickerViewController.swift
@@ -46,7 +46,12 @@ class CustomDatePickerViewController: UIViewController {
         self.navigationItem.prompt = "Schedule"
 
         //self.pickerView.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
-        self.pickerView.backgroundColor = .white
+        if #available(iOS 13.0, *) {
+            self.pickerView.backgroundColor = .systemBackground
+        } else {
+            // Fallback on earlier versions
+            self.pickerView.backgroundColor = .white
+        }
         self.pickerView.reloadAllComponents()
         self.pickerView.fixInView(self.view)
         self.view.addSubview(self.pickerView)

--- a/MiaomiaoClientUI/Cells/LFTimePickerController/CustomDatePickerViewController.swift
+++ b/MiaomiaoClientUI/Cells/LFTimePickerController/CustomDatePickerViewController.swift
@@ -45,13 +45,8 @@ class CustomDatePickerViewController: UIViewController {
         self.navigationItem.leftBarButtonItem = cancelButton
         self.navigationItem.prompt = "Schedule"
 
-        //self.pickerView.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
-        if #available(iOS 13.0, *) {
-            self.pickerView.backgroundColor = .systemBackground
-        } else {
-            // Fallback on earlier versions
-            self.pickerView.backgroundColor = .white
-        }
+
+        self.pickerView.backgroundColor = .MMSystemBackground
         self.pickerView.reloadAllComponents()
         self.pickerView.fixInView(self.view)
         self.view.addSubview(self.pickerView)

--- a/MiaomiaoClientUI/Controllers/BluetoothSelector/ExtendingAuthController.swift
+++ b/MiaomiaoClientUI/Controllers/BluetoothSelector/ExtendingAuthController.swift
@@ -159,7 +159,7 @@ public class ExtendingAuthController: NSObject, UITableViewDataSource, UITableVi
             return source.tableView(source.tableView, cellForRowAt: indexPath)
         }
 
-        var cell = AnnotatedSubtitleCell<CBPeripheral>(style: .subtitle, reuseIdentifier: nil)
+        let cell = AnnotatedSubtitleCell<CBPeripheral>(style: .subtitle, reuseIdentifier: nil)
         //tableView.dequeueReusableCell(withIdentifier: "UITableViewCell", for: indexPath)
 
         if let device = discoveredDevices[safe: indexPath.row] {

--- a/MiaomiaoClientUI/Controllers/BluetoothSelector/ExtendingAuthController.swift
+++ b/MiaomiaoClientUI/Controllers/BluetoothSelector/ExtendingAuthController.swift
@@ -163,7 +163,8 @@ public class ExtendingAuthController: NSObject, UITableViewDataSource, UITableVi
         //tableView.dequeueReusableCell(withIdentifier: "UITableViewCell", for: indexPath)
 
         if let device = discoveredDevices[safe: indexPath.row] {
-            cell.textLabel?.text = "\(device.name) "
+            let name = device.name ?? "Unknown"
+            cell.textLabel?.text = "\(name)"
             cell.detailTextLabel?.text = "\(device.identifier)"
             cell.textLabel?.numberOfLines = 0
             cell.textLabel?.lineBreakMode = .byWordWrapping

--- a/MiaomiaoClientUI/Controllers/MiaomiaoClientSettingsViewController.swift
+++ b/MiaomiaoClientUI/Controllers/MiaomiaoClientSettingsViewController.swift
@@ -296,10 +296,10 @@ public class MiaomiaoClientSettingsViewController: UITableViewController, SubVie
             case .bridgeType:
                 cell.textLabel?.text = LocalizedString("Bridge Type", comment: "Title Bridge Type")
 
-                cell.detailTextLabel?.text = UserDefaults.standard.preSelectedDevice?.bridgeType?.name
+                cell.detailTextLabel?.text = cgmManager?.getDeviceType()
             case .bridgeIdentifer:
                 cell.textLabel?.text = LocalizedString("Bridge Identifer", comment: "Title Bridge Identifier")
-                cell.detailTextLabel?.text = UserDefaults.standard.preSelectedDevice?.identifier
+                cell.detailTextLabel?.text = UserDefaults.standard.preSelectedDevice
             }
 
             return cell

--- a/MiaomiaoClientUI/UIColor.swift
+++ b/MiaomiaoClientUI/UIColor.swift
@@ -13,4 +13,11 @@ extension UIColor {
     private static func higRed() -> UIColor {
         return UIColor(red: 1, green: 59 / 255, blue: 48 / 255, alpha: 1)
     }
+
+    public static var MMSystemBackground: UIColor {
+        if #available(iOS 13, *) {
+            return .systemBackground
+        }
+        return UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+    }
 }

--- a/MiaomiaoClientUI/Views/SnoozeTableViewController/SnoozeTableViewController.swift
+++ b/MiaomiaoClientUI/Views/SnoozeTableViewController/SnoozeTableViewController.swift
@@ -39,7 +39,7 @@ public class SnoozeTableViewController: UITableViewController, UIPickerViewDataS
         let mins10 = 0.166_67
         let mins20 = mins10 * 2
         let mins30 = mins10 * 3
-        let mins40 = mins10 * 4
+        //let mins40 = mins10 * 4
 
         for hr in 0..<2 {
             for min in [0.0, mins20, mins20 * 2] {
@@ -105,6 +105,7 @@ public class SnoozeTableViewController: UITableViewController, UIPickerViewDataS
         self.tableView.rowHeight = 44
         tableView.contentInset = UIEdgeInsets.zero
         self.automaticallyAdjustsScrollViewInsets = false
+        
         tableView.tableFooterView = UIView()
         tableView.tableHeaderView = UIView()
     }


### PR DESCRIPTION
Remove the CompatibleLibreBluetoothDevice class (braking change).  CompatibleLibreBluetoothDevice objects were shadowing CBPeripheral objects. Use CBPeripheral objects directly, add necessary extensions methods.

This change will facilitate splitting  LibreBluetoothManager into Transmitter and transmitterDelegate later on